### PR TITLE
Split output bundles in modern and legacy bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ typings/
 
 # build output
 lib/
+esm/
+cjs/
 
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Usage
 
 ```jsx
-import {useMedia} from 'use-media';
+import useMedia from 'use-media';
 
 const Demo = () => {
   // Accepts an object of features to test
@@ -20,4 +20,10 @@ const Demo = () => {
     </div>
   );
 };
+```
+
+The default module bundle is compiled for modern browsers. If you need to support IE11 and other browsers without support for arrow functions, template literals, etc, you can use the CommonJS bundle:
+
+```
+import useMedia from 'use-media/cjs`;
 ```

--- a/package.json
+++ b/package.json
@@ -2,15 +2,19 @@
   "name": "use-media",
   "version": "1.1.0",
   "description": "useMedia React hook",
-  "main": "lib/index.js",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
   "files": [
-    "lib/"
+    "esm/",
+    "cjs/"
   ],
-  "types": "lib/index.d.ts",
-  "typings": "lib/index.d.ts",
+  "types": "esm/index.d.ts",
+  "typings": "esm/index.d.ts",
   "scripts": {
     "test": "echo 'hmmmm....'",
-    "build": "tsc",
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --target es5 --outDir cjs",
     "release": "semantic-release"
   },
   "author": "@streamich",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import * as React from 'react';
-
-const { useState, useEffect } = React;
+import { useEffect, useState } from 'react';
 
 type MediaQueryObject = { [key: string]: string | number | boolean };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,12 +14,13 @@
     "noImplicitReturns": true,
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": true,
-    "outDir": "lib",
+    "outDir": "esm",
     "lib": ["es2018", "dom"]
   },
   "exclude": [
     "node_modules",
-    "lib",
+    "esm",
+    "cjs",
     "**/__tests__/**/*",
     "**/__stories__/**/*",
     "*.test.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "commonjs",
     "moduleResolution": "node",
     "jsx": "react",
     "declaration": true,


### PR DESCRIPTION
The current 2018 target means that the code will not run in browsers not
supporting let, const, arrow functions, etc. With this change you can
opt in to a legacy mode with

    import useMedia from 'use-media/cjs';

The cjs bundle will use commonjs modules and the esm bundle will use standard modules and be chosen automatically by Rollup and Webpack.