### PR TITLE
Use target ES5 to enable IE11 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
     "jsx": "react",


### PR DESCRIPTION
The size difference between the bundles is no more than 80 bytes, so I think this is the better and simpler approach compared to #5 to achieve better browser compatibility.