### PR TITLE
🔧Fix SSR and check for window undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { DependencyList, EffectCallback } from 'react';
-import * as React from 'react';
+import { DependencyList, EffectCallback } from "react";
+import * as React from "react";
 
 const { useState, useEffect, useLayoutEffect } = React;
 
@@ -8,20 +8,31 @@ type MediaQueryObject = { [key: string]: string | number | boolean };
 const camelToHyphen = (str: string) =>
   str.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`).toLowerCase();
 
+const noWindowMatches: MediaQueryList = {
+  media: "",
+  addListener: noop,
+  removeListener: noop,
+  matches: false,
+  onchange: noop,
+  addEventListener: noop,
+  removeEventListener: noop,
+  dispatchEvent: (_: Event) => true
+};
+
 const objectToString = (query: string | MediaQueryObject) => {
-  if (typeof query === 'string') return query;
+  if (typeof query === "string") return query;
   return Object.entries(query)
     .map(([feature, value]) => {
       feature = camelToHyphen(feature);
-      if (typeof value === 'boolean') {
+      if (typeof value === "boolean") {
         return value ? feature : `not ${feature}`;
       }
-      if (typeof value === 'number' && /[height|width]$/.test(feature)) {
+      if (typeof value === "number" && /[height|width]$/.test(feature)) {
         value = `${value}px`;
       }
       return `(${feature}: ${value})`;
     })
-    .join(' and ');
+    .join(" and ");
 };
 
 type Effect = (effect: EffectCallback, deps?: DependencyList) => void;
@@ -33,7 +44,10 @@ const createUseMedia = (effect: Effect) => (
   const query = objectToString(rawQuery);
   effect(() => {
     let mounted = true;
-    const mql = window.matchMedia(query);
+    const mql =
+      typeof window === "undefined"
+        ? noWindowMatches
+        : window.matchMedia(query);
     const onChange = () => {
       if (!mounted) return;
       setState(!!mql.matches);
@@ -51,6 +65,7 @@ const createUseMedia = (effect: Effect) => (
   return state;
 };
 
+function noop() {}
 
 export const useMedia = createUseMedia(useEffect);
 export const useMediaLayout = createUseMedia(useLayoutEffect);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { DependencyList, EffectCallback } from "react";
-import * as React from "react";
+import { DependencyList, EffectCallback } from 'react';
+import * as React from 'react';
 
 const { useState, useEffect, useLayoutEffect } = React;
 
@@ -9,7 +9,7 @@ const camelToHyphen = (str: string) =>
   str.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`).toLowerCase();
 
 const noWindowMatches: MediaQueryList = {
-  media: "",
+  media: '',
   addListener: noop,
   removeListener: noop,
   matches: false,
@@ -20,19 +20,19 @@ const noWindowMatches: MediaQueryList = {
 };
 
 const objectToString = (query: string | MediaQueryObject) => {
-  if (typeof query === "string") return query;
+  if (typeof query === 'string') return query;
   return Object.entries(query)
     .map(([feature, value]) => {
       feature = camelToHyphen(feature);
-      if (typeof value === "boolean") {
+      if (typeof value === 'boolean') {
         return value ? feature : `not ${feature}`;
       }
-      if (typeof value === "number" && /[height|width]$/.test(feature)) {
+      if (typeof value === 'number' && /[height|width]$/.test(feature)) {
         value = `${value}px`;
       }
       return `(${feature}: ${value})`;
     })
-    .join(" and ");
+    .join(' and ');
 };
 
 type Effect = (effect: EffectCallback, deps?: DependencyList) => void;
@@ -45,7 +45,7 @@ const createUseMedia = (effect: Effect) => (
   effect(() => {
     let mounted = true;
     const mql =
-      typeof window === "undefined"
+      typeof window === 'undefined'
         ? noWindowMatches
         : window.matchMedia(query);
     const onChange = () => {


### PR DESCRIPTION
Can't call `window.matchMedia` when `window` is `undefined`.

This PR introduces a conditional check for `window`, and returns a boilerplate `MediaQueryList` is `true`.

cc/ @streamich 