### PR TITLE
Allow initiator func on default value

### DIFF
--- a/src/useMedia.ts
+++ b/src/useMedia.ts
@@ -15,7 +15,7 @@ export const mockMediaQueryList: MediaQueryList = {
 
 const createUseMedia = (effect: Effect) => (
   rawQuery: string | MediaQueryObject,
-  defaultState = false,
+  defaultState: boolean | (() => boolean) = false,
 ) => {
   const [state, setState] = useState(defaultState);
   const query = queryObjectToString(rawQuery);


### PR DESCRIPTION
Hey, I'm updating the types to allow passing an initiator function. I'm trying to implement the following.

<img width="1242" alt="image" src="https://github.com/user-attachments/assets/7ea3e870-b45f-425a-8377-2ba2321732ba">

I don't want to use an arbitrary default value if the app is hydrated, instead, I want to run the query matcher and use that as my initial value.